### PR TITLE
Add rtl::get<T> class

### DIFF
--- a/include/rtl/get.h
+++ b/include/rtl/get.h
@@ -1,0 +1,30 @@
+#pragma once
+
+
+namespace rtl
+{
+	template< typename T >
+	class get
+	{
+		std::function<T()> mGet;
+	public:
+		get( var<T>& ref ) : mGet([&ref](){ return ref(); })
+		{
+		}
+		
+		get( const T& value )
+		{
+			mGet = [value](){ return value; };
+		}
+		
+		get( std::function<T()> getter )
+		{
+			mGet = std::move(getter);
+		}
+		
+		T operator ()() const
+		{
+			return mGet();
+		}
+	};
+}


### PR DESCRIPTION
This is like rtl::ref<T> but only for getting the value, and hence is really just a function with some syntax sugar